### PR TITLE
Add a prepare-release target…

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: task-git
-version: 0.0.1
+version: 0.1.0
 description: |
   This Task represents Git and is able to initialize and clone a remote
   repository on the informed Workspace. It's likely to become the first `step`


### PR DESCRIPTION
… and update the version to 0.1.0 to prepare the release to come.

```
$ make prepare-release
mkdir -p /tmp/task-git-0.1.0/task/task-git || true
helm template  . > /tmp/task-git-0.1.0/task/task-git/task-git.yaml
cp README.md /tmp/task-git-0.1.0/task/task-git/
go run github.com/openshift-pipelines/tektoncd-catalog/cmd/catalog-cd@main release --output release --version 0.1.0 /tmp/task-git-0.1.0/task/task-git
# Found 1 path to inspect!
# Scan Tekton resources on: /tmp/task-git-0.1.0/task/task-git
# Loading resource file: "/tmp/task-git-0.1.0/task/task-git/task-git.yaml"
# Saving release contract at "release/catalog.yaml"
# Creating tarball at "release/resources.tar.gz"
Now you can release:
  git tag v0.1.0
  gh release create v0.1.0 --generate-notes
  gh release upload v0.1.0 release/catalog.yaml
  gh release upload v0.1.0 release/resources.tar.gz
```

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
